### PR TITLE
[embedlite-components] More UA override tweaking for youtube.com. Fixes JB#31842

### DIFF
--- a/jscomps/UserAgentOverrideHelper.js
+++ b/jscomps/UserAgentOverrideHelper.js
@@ -98,7 +98,7 @@ var UserAgent = {
         }
         if (!ua.contains("Android")) {
           // Nexus 7 Android chrome has best capabilities
-          return ua.replace("Linux", "Android 4.4.2").replace("Unix", "Android 4.4.2");
+          return ua.replace("Linux", "Android 4.4.2").replace("Unix", "Android 4.4.2").replace("Mobile", "");
         }
       } else if (this.NOKIA_HERE_DOMAIN.test(aUri.host)) {
         // Send the phone UA to here


### PR DESCRIPTION
Restore back "Mobile" removal from the user agent. "Maemo" is kept
in the user agent string so that youtube server serves HTML5 videos.
